### PR TITLE
Metamask alerts

### DIFF
--- a/src/web3/Web3Container.js
+++ b/src/web3/Web3Container.js
@@ -31,11 +31,25 @@ export default class Web3Container extends React.Component {
       networkId: 1,
       tokenRegistryContractAddress: `0x0b1ba0af832d7c05fd64161e0db78e85978e8082`
     });
-    const tokens = await zeroEx.tokenRegistry.getTokensAsync();
     const b0x = new B0xJS(web3.currentProvider);
+
+    // Get tokens from the token registry
+    let tokens;
+    try {
+      tokens = await zeroEx.tokenRegistry.getTokensAsync();
+    } catch (err) {
+      alert(
+        `You may be on the wrong network, please check MetaMask and refresh the page.`
+      );
+      console.error(err);
+      return;
+    }
+
+    // Get accounts
     const accounts = await web3.eth.getAccounts();
     if (!accounts[0]) {
       alert(`Please unlock your MetaMask account, and then refresh the page.`);
+      return;
     }
     this.setState({ loading: false, web3, zeroEx, tokens, b0x, accounts });
   }

--- a/src/web3/Web3Container.js
+++ b/src/web3/Web3Container.js
@@ -34,6 +34,9 @@ export default class Web3Container extends React.Component {
     const tokens = await zeroEx.tokenRegistry.getTokensAsync();
     const b0x = new B0xJS(web3.currentProvider);
     const accounts = await web3.eth.getAccounts();
+    if (!accounts[0]) {
+      alert(`Please unlock your MetaMask account, and then refresh the page.`);
+    }
     this.setState({ loading: false, web3, zeroEx, tokens, b0x, accounts });
   }
 


### PR DESCRIPTION
Some basic alerts to let the user know that either:

1. Their MetaMask is set to the wrong network, or;
2. Their MetaMask account is locked.

The user is prompted to either change the network or unlock the account and then refresh the page.